### PR TITLE
Add Twitter thread one-pager demo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/twitter-thread-onepager/README.md
+++ b/twitter-thread-onepager/README.md
@@ -1,0 +1,28 @@
+# Twitter Thread One-Pager
+
+This small demo application converts a Twitter thread URL into a simple one-page HTML document including images, videos or GIFs referenced in the thread. It also stores previously processed threads in a SQLite database and exposes search and history endpoints.
+
+## Features
+
+- Paste a Twitter thread URL and receive HTML content for the whole thread.
+- Stores processed threads for quick retrieval via `/history`.
+- Full–text search of stored threads via `/search?q=...`.
+- Simple retrieval of an individual thread HTML via `/thread/:id`.
+
+## Requirements
+
+- Node.js 18+.
+- Twitter API credentials set in environment variables:
+  - `TWITTER_API_KEY`
+  - `TWITTER_API_SECRET`
+  - `TWITTER_ACCESS_TOKEN`
+  - `TWITTER_ACCESS_SECRET`
+
+## Run
+
+```bash
+npm install
+npm start
+```
+
+The server listens on port `3000` by default.

--- a/twitter-thread-onepager/index.js
+++ b/twitter-thread-onepager/index.js
@@ -1,0 +1,146 @@
+const express = require('express');
+const { TwitterApi } = require('twitter-api-v2');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+const db = new sqlite3.Database(path.join(__dirname, 'threads.db'));
+
+// Initialize DB
+function initDB() {
+  db.run(`CREATE TABLE IF NOT EXISTS threads (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url TEXT UNIQUE,
+      html TEXT,
+      text TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+  // for simple full text search
+  db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS thread_index USING fts5(text, url, content='threads', content_rowid='id')`);
+}
+initDB();
+
+// create index triggers
+function createTriggers() {
+  db.run(`CREATE TRIGGER IF NOT EXISTS threads_ai AFTER INSERT ON threads BEGIN
+    INSERT INTO thread_index(rowid, text, url) VALUES (new.id, new.text, new.url);
+  END;`);
+
+  db.run(`CREATE TRIGGER IF NOT EXISTS threads_ad AFTER DELETE ON threads BEGIN
+    INSERT INTO thread_index(thread_index, rowid, text, url) VALUES('delete', old.id, old.text, old.url);
+  END;`);
+
+  db.run(`CREATE TRIGGER IF NOT EXISTS threads_au AFTER UPDATE ON threads BEGIN
+    INSERT INTO thread_index(thread_index, rowid, text, url) VALUES('delete', old.id, old.text, old.url);
+    INSERT INTO thread_index(rowid, text, url) VALUES (new.id, new.text, new.url);
+  END;`);
+}
+createTriggers();
+
+// Config for Twitter API (requires environment variables)
+const twitterClient = new TwitterApi({
+  appKey: process.env.TWITTER_API_KEY,
+  appSecret: process.env.TWITTER_API_SECRET,
+  accessToken: process.env.TWITTER_ACCESS_TOKEN,
+  accessSecret: process.env.TWITTER_ACCESS_SECRET,
+});
+
+async function fetchThread(url) {
+  // Extract tweet id from URL
+  const match = url.match(/status\/(\d+)/);
+  if (!match) throw new Error('Invalid twitter status URL');
+  const tweetId = match[1];
+
+  const thread = await twitterClient.v2.singleTweet(tweetId, {
+    expansions: ['attachments.media_keys', 'author_id', 'referenced_tweets.id'],
+    'media.fields': ['url', 'preview_image_url'],
+    'tweet.fields': ['conversation_id', 'author_id', 'created_at', 'entities'],
+    'user.fields': ['name', 'username', 'profile_image_url'],
+  });
+
+  const conversationId = thread.data.conversation_id;
+  const searchRes = await twitterClient.v2.search(`conversation_id:${conversationId} from:${thread.data.author_id}`, {
+    expansions: ['attachments.media_keys'],
+    'media.fields': ['url', 'preview_image_url', 'type'],
+    max_results: 100,
+  });
+
+  const tweets = searchRes.tweets || searchRes.data || [];
+  const includes = searchRes.includes || {};
+  tweets.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  return { tweets, includes };
+}
+
+function renderHTML(tweets, includes = {}) {
+  let body = '';
+  const mediaMap = {};
+  if (includes.media) {
+    includes.media.forEach(m => {
+      mediaMap[m.media_key] = m;
+    });
+  }
+  tweets.forEach(t => {
+    const text = t.text.replace(/\n/g, '<br/>');
+    body += `<p>${text}</p>`;
+    if (t.attachments && t.attachments.media_keys) {
+      t.attachments.media_keys.forEach(mk => {
+        const m = mediaMap[mk];
+        if (!m) return;
+        if (m.type === 'photo') {
+          body += `<img src="${m.url}" style="max-width:100%"/>`;
+        } else if (m.type === 'animated_gif' || m.type === 'video') {
+          const src = m.preview_image_url || m.url;
+          body += `<video src="${src}" controls style="max-width:100%"></video>`;
+        }
+      });
+    }
+  });
+  return `<!doctype html><html><body>${body}</body></html>`;
+}
+
+app.post('/api/thread', async (req, res) => {
+  const { url } = req.body;
+  if (!url) return res.status(400).json({ error: 'Missing url' });
+  try {
+    const { tweets, includes } = await fetchThread(url);
+    const html = renderHTML(tweets, includes);
+    const text = tweets.map(t => t.text).join('\n');
+    db.run('INSERT OR REPLACE INTO threads(url, html, text) VALUES(?,?,?)', [url, html, text]);
+    res.json({ html });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/history', (req, res) => {
+  db.all('SELECT id, url, created_at FROM threads ORDER BY created_at DESC', [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.get('/search', (req, res) => {
+  const q = req.query.q;
+  db.all('SELECT url, snippet(thread_index) as snippet FROM thread_index WHERE thread_index MATCH ? LIMIT 20', [q], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.get('/thread/:id', (req, res) => {
+  const id = req.params.id;
+  db.get('SELECT html FROM threads WHERE id = ?', [id], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).send('Not found');
+    res.send(row.html);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/twitter-thread-onepager/package.json
+++ b/twitter-thread-onepager/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "twitter-thread-onepager",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "express": "^5.1.0",
+    "sqlite3": "^5.1.7",
+    "twitter-api-v2": "^1.24.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create `twitter-thread-onepager` demo with Express and SQLite
- allow converting Twitter threads to HTML pages with media
- store processed threads for history and search
- ignore node_modules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688306bafe24832d83b27da0a7575243